### PR TITLE
Show cause of the error when fixture can't be loaded

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 Version 1.1.29 under development
 --------------------------------
 
+- New: Improved error messaging in the database fixture manager file (eduardor2k)
 - Bug #4516: PHP 8 compatibility: Allow union types and intersection types in action declarations (wtommyw)
 - Bug #4523: Fixed translated in Greek class messages in framework requirements view, which they should not be translated (lourdas)
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,9 +4,9 @@
 Version 1.1.29 under development
 --------------------------------
 
-- New: Improved error messaging in the database fixture manager file (eduardor2k)
 - Bug #4516: PHP 8 compatibility: Allow union types and intersection types in action declarations (wtommyw)
 - Bug #4523: Fixed translated in Greek class messages in framework requirements view, which they should not be translated (lourdas)
+- Enh #4529: Exceptions thrown while loading fixture file rows now contain more details (eduardor2k)
 
 Version 1.1.28 February 28, 2023
 --------------------------------

--- a/framework/test/CDbFixtureManager.php
+++ b/framework/test/CDbFixtureManager.php
@@ -173,7 +173,7 @@ class CDbFixtureManager extends CApplicationComponent
 			try {
 				$builder->createInsertCommand($table,$row)->execute();
 			} catch (CException $e) {
-				throw new CException('Exception loading row ' . $alias . ' in fixture ' . $fileName, $e->getCode(), $e);
+				throw new CException('Exception loading row ' . $alias . ' in fixture ' . $fileName . ', Error: ' . $e->getMessage(), $e->getCode(), $e);
 			}
 			$primaryKey=$table->primaryKey;
 			if($table->sequenceName!==null)


### PR DESCRIPTION
When a fixture can't be loaded, you only get a generic error telling you which fixture can't be loaded, it would be more helpful if in that message we get the cause of the error

`1) Unit\RequestApiTest::testCreate
CException: Exception loading row req1 in fixture /var/www/html/test/yiitools/protected/tests/fixtures/requests.php` 

to

`1) Unit\RequestApiTest::testCreate
CException: Exception loading row req1 in fixture /var/www/html/test/yiitools/protected/tests/fixtures/requests.php Error: CDbCommand failed to execute the SQL statement: SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect datetime value: '1691576897' for column 'date_added' at row 1`

<!--
Note that only PHP 7 and PHP 8 compatibility fixes are accepted. Please report security issues to maintainers privately.
-->

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
